### PR TITLE
Improvements to multi-hit moves (motivated by Population Bomb)

### DIFF
--- a/calc/src/data/moves.ts
+++ b/calc/src/data/moves.ts
@@ -4528,7 +4528,7 @@ const SV_PATCH: {[name: string]: DeepPartial<MoveData>} = {
     maxPower: 90,
     makesContact: true,
     isSlicing: true,
-    multihit: 10,
+    multihit: [2, 10],
   },
   Pounce: {
     bp: 50,

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -550,6 +550,11 @@
                     <option value="3">3 hits</option>
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
+                    <option value="6">6 hits</option>
+                    <option value="7">7 hits</option>
+                    <option value="8">8 hits</option>
+                    <option value="9">9 hits</option>
+                    <option value="10">10 hits</option>
                 </select>
                 <select class="stat-drops calc-trigger hide" title="How many times was this move used in a row?">>
                     <option value="1">Once</option>
@@ -584,6 +589,11 @@
                     <option value="3">3 hits</option>
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
+                    <option value="6">6 hits</option>
+                    <option value="7">7 hits</option>
+                    <option value="8">8 hits</option>
+                    <option value="9">9 hits</option>
+                    <option value="10">10 hits</option>
                 </select>
                 <select class="stat-drops calc-trigger hide" title="How many times was this move used in a row?">>
                     <option value="1">Once</option>
@@ -618,6 +628,11 @@
                     <option value="3">3 hits</option>
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
+                    <option value="6">6 hits</option>
+                    <option value="7">7 hits</option>
+                    <option value="8">8 hits</option>
+                    <option value="9">9 hits</option>
+                    <option value="10">10 hits</option>
                 </select>
                 <select class="stat-drops calc-trigger hide" title="How many times was this move used in a row?">>
                     <option value="1">Once</option>
@@ -652,6 +667,11 @@
                     <option value="3">3 hits</option>
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
+                    <option value="6">6 hits</option>
+                    <option value="7">7 hits</option>
+                    <option value="8">8 hits</option>
+                    <option value="9">9 hits</option>
+                    <option value="10">10 hits</option>
                 </select>
                 <select class="stat-drops calc-trigger hide" title="How many times was this move used in a row?">>
                     <option value="1">Once</option>
@@ -1536,6 +1556,11 @@
                     <option value="3">3 hits</option>
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
+                    <option value="6">6 hits</option>
+                    <option value="7">7 hits</option>
+                    <option value="8">8 hits</option>
+                    <option value="9">9 hits</option>
+                    <option value="10">10 hits</option>
                 </select>
                 <select class="stat-drops calc-trigger hide" title="How many times was this move used in a row?">>
                     <option value="1">Once</option>
@@ -1570,6 +1595,11 @@
                     <option value="3">3 hits</option>
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
+                    <option value="6">6 hits</option>
+                    <option value="7">7 hits</option>
+                    <option value="8">8 hits</option>
+                    <option value="9">9 hits</option>
+                    <option value="10">10 hits</option>
                 </select>
                 <select class="stat-drops calc-trigger hide" title="How many times was this move used in a row?">>
                     <option value="1">Once</option>
@@ -1604,6 +1634,11 @@
                     <option value="3">3 hits</option>
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
+                    <option value="6">6 hits</option>
+                    <option value="7">7 hits</option>
+                    <option value="8">8 hits</option>
+                    <option value="9">9 hits</option>
+                    <option value="10">10 hits</option>
                 </select>
                 <select class="stat-drops calc-trigger hide" title="How many times was this move used in a row?">>
                     <option value="1">Once</option>
@@ -1638,6 +1673,11 @@
                     <option value="3">3 hits</option>
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
+                    <option value="6">6 hits</option>
+                    <option value="7">7 hits</option>
+                    <option value="8">8 hits</option>
+                    <option value="9">9 hits</option>
+                    <option value="10">10 hits</option>
                 </select>
                 <select class="stat-drops calc-trigger hide" title="How many times was this move used in a row?">>
                     <option value="1">Once</option>

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -435,6 +435,18 @@ $(".move-selector").change(function () {
 		moveGroupObj.children(".stat-drops").hide();
 		moveGroupObj.children(".move-hits").show();
 		var pokemon = $(this).closest(".poke-info");
+
+		// hide any numbers not in the range
+		moveGroupObj.children(".move-hits").children().prop('disabled', true).hide()
+		var min = move.multihit[0];
+		var max = move.multihit[1];
+		var $moveHits = moveGroupObj.children(".move-hits");
+		// create inclusive range and show hit values in range
+		[...Array(max - min + 1).keys()].forEach(i => {
+			$moveHits.children(`option[value="${i + min}"]`).prop('disabled', false).show();
+		});
+
+		// automatically select 5 if the pokemon's ability is Skill Link
 		var moveHits = (pokemon.find(".ability").val() === 'Skill Link') ? 5 : 3;
 		moveGroupObj.children(".move-hits").val(moveHits);
 	} else if (dropsStats) {


### PR DESCRIPTION
# Updates
- Change Population bomb to use a range style hits property.
  - `[2, 10]` instead of just `10`
- improve logic for showing number of hits in calc

## Icicle Spear (2-5 hits)
<img width="426" alt="Screenshot 2023-04-07 at 3 31 13 PM" src="https://user-images.githubusercontent.com/1904364/230675231-b7f2e30d-3445-43bb-b1f7-0d5db45ab556.png">

## Population Bomb (2-10 hits)
<img width="433" alt="Screenshot 2023-04-07 at 3 30 57 PM" src="https://user-images.githubusercontent.com/1904364/230675237-96a63bea-a686-4126-b43d-1f77e7b602f0.png">

