### PR TITLE
Fixed Defense Cheer Calculations

### DIFF
--- a/calc/src/desc.ts
+++ b/calc/src/desc.ts
@@ -37,6 +37,7 @@ export interface RawDesc {
   isCritical?: boolean;
   isLightScreen?: boolean;
   isDefCheered?: boolean;
+  isDefCheeredBodyPress?: boolean;
   isBurned?: boolean;
   isProtected?: boolean;
   isReflect?: boolean;
@@ -890,7 +891,10 @@ function buildDescription(description: RawDesc, attacker: Pokemon, defender: Pok
     output += 'Helping Hand ';
   }
   if (description.isAtkCheered) {
-    output += 'Atk cheer ' ;
+    output += 'Atk Cheer ';
+  }
+  if (description.isDefCheeredBodyPress) {
+    output += 'Def Cheer ';
   }
   if (description.isFlowerGiftAttacker) {
     output += ' with an ally\'s Flower Gift ';
@@ -971,7 +975,7 @@ function buildDescription(description: RawDesc, attacker: Pokemon, defender: Pok
     if(description.isReflect || description.isLightScreen){
         output += ' and Def Cheer';
     } else {
-        output += ' through Def cheer';
+        output += ' through Def Cheer';
     }
   }
   if (description.isFlowerGiftDefender) {

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -931,18 +931,6 @@ export function calculateBPModsSMSSSV(
     desc.isHelpingHand = true;
   }
 
-  // if ((field.attackerSide.isAtkCheered && !move.named('Body Press') && !move.named('Foul Play')) ||
-  //   (move.named('Foul Play') && field.defenderSide.isAtkCheered)
-  // ) {
-  //   bpMods.push(6144);
-  //   desc.isAtkCheered = true;
-  // }
-
-  // if (move.named('Body Press') && field.attackerSide.isDefCheered){
-  //   bpMods.push(6144);
-  //   desc.isDefCheered = true;
-  // }
-
   // Field effects
 
   const terrainMultiplier = gen.num > 7 ? 5325 : 6144;
@@ -1173,6 +1161,7 @@ export function calculateAttackSMSSSV(
     attack = pokeRound((attack * 3) / 2);
     desc.attackerAbility = attacker.ability;
   }
+
   const atMods = calculateAtModsSMSSSV(gen, attacker, defender, move, field, desc);
   attack = OF16(Math.max(1, pokeRound((attack * chainMods(atMods, 410, 131072)) / 4096)));
   return attack;
@@ -1270,21 +1259,6 @@ export function calculateAtModsSMSSSV(
     atMods.push(3072);
   }
 
-  if (field.attackerSide.isAtkCheered && !move.named('Body Press') && !move.named('Foul Play')) {
-    atMods.push(6144);
-    desc.isAtkCheered = true;
-  }
-
-  if (move.named('Foul Play') && field.defenderSide.isAtkCheered) {
-    atMods.push(6144);
-    desc.isAtkCheered = true;
-  }
-
-  if (move.named('Body Press') && field.attackerSide.isDefCheered) {
-    atMods.push(6144);
-    desc.isDefCheered = true;
-  }
-
   if (
     (attacker.hasAbility('Protosynthesis') &&
       (field.hasWeather('Sun') || attacker.hasItem('Booster Energy'))) ||
@@ -1329,6 +1303,22 @@ export function calculateAtModsSMSSSV(
     atMods.push(6144);
     desc.attackerItem = attacker.item;
   }
+
+  if (field.attackerSide.isAtkCheered && !move.named('Body Press') && !move.named('Foul Play')) {
+    atMods.push(6144);
+    desc.isAtkCheered = true;
+  }
+
+  if (move.named('Foul Play') && field.defenderSide.isAtkCheered) {
+    atMods.push(6144);
+    desc.isAtkCheered = true;
+  }
+
+  if (move.named('Body Press') && field.attackerSide.isDefCheered) {
+    atMods.push(6144);
+    desc.isDefCheeredBodyPress = true;
+  }
+
   return atMods;
 }
 
@@ -1438,11 +1428,6 @@ export function calculateDfModsSMSSSV(
     dfMods.push(3072);
   }
 
-  if (field.defenderSide.isDefCheered){
-    dfMods.push(6144);
-    desc.isDefCheered = true;
-  }
-
   if (
     (defender.hasAbility('Protosynthesis') &&
     (field.hasWeather('Sun') || attacker.hasItem('Booster Energy'))) ||
@@ -1469,6 +1454,12 @@ export function calculateDfModsSMSSSV(
     dfMods.push(8192);
     desc.defenderItem = defender.item;
   }
+
+  if (field.defenderSide.isDefCheered){
+    dfMods.push(6144);
+    desc.isDefCheered = true;
+  }
+
   return dfMods;
 }
 
@@ -1501,10 +1492,6 @@ export function calculateFinalModsSMSSSV(
     finalMods.push(field.gameType !== 'Singles' ? 2732 : 2048);
     desc.isAuroraVeil = true;
   }
-  // if (field.defenderSide.isDefCheered){
-  //   finalMods.push(2732);
-  //   desc.isDefCheered = true;
-  // }
 
   if (attacker.hasAbility('Neuroforce') && typeEffectiveness > 1) {
     finalMods.push(5120);

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -931,17 +931,17 @@ export function calculateBPModsSMSSSV(
     desc.isHelpingHand = true;
   }
 
-  if ((field.attackerSide.isAtkCheered && !move.named('Body Press') && !move.named('Foul Play')) ||
-    (move.named('Foul Play') && field.defenderSide.isAtkCheered)
-  ) {
-    bpMods.push(6144);
-    desc.isAtkCheered = true;
-  }
+  // if ((field.attackerSide.isAtkCheered && !move.named('Body Press') && !move.named('Foul Play')) ||
+  //   (move.named('Foul Play') && field.defenderSide.isAtkCheered)
+  // ) {
+  //   bpMods.push(6144);
+  //   desc.isAtkCheered = true;
+  // }
 
-  if (move.named('Body Press') && field.attackerSide.isDefCheered){
-    bpMods.push(6144);
-    desc.isDefCheered = true;
-  }
+  // if (move.named('Body Press') && field.attackerSide.isDefCheered){
+  //   bpMods.push(6144);
+  //   desc.isDefCheered = true;
+  // }
 
   // Field effects
 
@@ -1270,6 +1270,21 @@ export function calculateAtModsSMSSSV(
     atMods.push(3072);
   }
 
+  if (field.attackerSide.isAtkCheered && !move.named('Body Press') && !move.named('Foul Play')) {
+    atMods.push(6144);
+    desc.isAtkCheered = true;
+  }
+
+  if (move.named('Foul Play') && field.defenderSide.isAtkCheered) {
+    atMods.push(6144);
+    desc.isAtkCheered = true;
+  }
+
+  if (move.named('Body Press') && field.attackerSide.isDefCheered) {
+    atMods.push(6144);
+    desc.isDefCheered = true;
+  }
+
   if (
     (attacker.hasAbility('Protosynthesis') &&
       (field.hasWeather('Sun') || attacker.hasItem('Booster Energy'))) ||
@@ -1423,6 +1438,11 @@ export function calculateDfModsSMSSSV(
     dfMods.push(3072);
   }
 
+  if (field.defenderSide.isDefCheered){
+    dfMods.push(6144);
+    desc.isDefCheered = true;
+  }
+
   if (
     (defender.hasAbility('Protosynthesis') &&
     (field.hasWeather('Sun') || attacker.hasItem('Booster Energy'))) ||
@@ -1481,10 +1501,10 @@ export function calculateFinalModsSMSSSV(
     finalMods.push(field.gameType !== 'Singles' ? 2732 : 2048);
     desc.isAuroraVeil = true;
   }
-  if (field.defenderSide.isDefCheered){
-    finalMods.push(2732);
-    desc.isDefCheered = true;
-  }
+  // if (field.defenderSide.isDefCheered){
+  //   finalMods.push(2732);
+  //   desc.isDefCheered = true;
+  // }
 
   if (attacker.hasAbility('Neuroforce') && typeEffectiveness > 1) {
     finalMods.push(5120);


### PR DESCRIPTION
<H2>Moved defense cheer modifier from final modifiers (finalMods) to defense modifiers (dfMods). </H2>
Data to support this change:

When defense cheers are calculated via finalMods:
`0+ SpA Tera Ghost Typhlosion Shadow Ball vs. 0 HP / 0 SpD Stonjourner through Def cheer: 210-248 (61.5 - 72.7%) -- guaranteed 2HKO 
Possible damage amounts: (210, 213, 215, 218, 220, 223, 225, 228, 230, 233, 235, 238, 240, 243, 245, 248)`

When defense cheers are calculated via dfMods:
`0+ SpA Tera Ghost Typhlosion Shadow Ball vs. 0 HP / 0 SpD Stonjourner through Def cheer: 211-249 (61.8 - 73%) -- guaranteed 2HKO 
Possible damage amounts: (211, 213, 216, 219, 220, 223, 226, 228, 231, 234, 235, 238, 241, 243, 246, 249)`

Data samples collected (damage dealt by shadow ball onto Stonjourner): 246, 241, 226, 234, 249, 216, 220, 246, 226, 226, 226, 213


<H2>Other Changes</H2>

- Moved attack cheer modifier from base power modifiers (bpMods) to attack modifiers (atMods)
- Also fixed attacker side defense cheer body press description