### PR TITLE
Fixed Screen Reduction Rate

### DIFF
--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -1050,7 +1050,7 @@ function getMoveDetails(moveInfo, species, ability, item, useMax) {
 }
 
 function createField() {
-	var gameType = $("input:radio[name='format']:checked").val();
+	var gameType = "Doubles";
 	var isBeadsOfRuin = $("#beads").prop("checked");
 	var isTabletsOfRuin = $("#tablets").prop("checked");
 	var isSwordOfRuin = $("#sword").prop("checked");


### PR DESCRIPTION
Simple change to always use the doubles screen rate.

I think what happened is that the "Singles|Doubles" button got deleted so the value for the gameType always defaulted to null/Singles whenever the value from the non-existent button was read.