### PR TITLE
Fix Helping Hand interaction with multi-hit moves

### DIFF
--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -638,6 +638,16 @@ export function calculateSMSSSV(
       let damageMultiplier = 0;
       damage = damage.map(affectedAmount => {
         if (times) {
+          field.attackerSide.isHelpingHand = false; // Helping Hand only applies to the first hit in Tera Raids
+          const newBasePower = calculateBasePowerSMSSSV(
+            gen,
+            attacker,
+            defender,
+            move,
+            field,
+            hasAteAbilityTypeChange,
+            desc
+          )
           const newFinalMods = calculateFinalModsSMSSSV(
             gen,
             attacker,
@@ -654,7 +664,7 @@ export function calculateSMSSSV(
             gen,
             attacker,
             defender,
-            basePower,
+            newBasePower,
             attack,
             newDefense,
             move,

--- a/calc/src/test/calc.test.ts
+++ b/calc/src/test/calc.test.ts
@@ -1020,6 +1020,19 @@ describe('calc', () => {
             "0 Atk Weavile with an ally's Flower Gift Power Spot boosted switching boosted Pursuit (80 BP) vs. 0 HP / 0 Def Vulpix in Sun: 399-469 (183.8 - 216.1%) -- guaranteed OHKO"
           );
         });
+
+        test(`Multi-hit interaction with Helping Hand for Tera Raids`, () => {
+          const result = calculate(
+            Pokemon('Mamoswine'),
+            Pokemon('Hippowdon'),
+            Move('Icicle Spear'),
+            Field({attackerSide: {isHelpingHand: true}}),
+          );
+          expect(result.range()).toEqual([206, 248]);
+          expect(result.desc()).toBe(
+            '0 Atk Mamoswine Helping Hand Icicle Spear (3 hits) vs. 0 HP / 0 Def Hippowdon: 206-248 (57.7 - 69.4%) -- approx. 2HKO'
+          );
+        });
       });
     });
   });


### PR DESCRIPTION
Annoyingly, Helping Hand only applies a boost to the first hit of a multi-hit move in Tera Raids (whereas in Doubles, it lasts for a whole turn).

Without HH:
0 Atk Mamoswine Icicle Spear (3 hits) vs. 0 HP / 0 Def Hippowdon: 180-216 (50.4 - 60.5%) -- approx. 2HKO

Current with HH (boost across all 3 hits):
0 Atk Mamoswine Helping Hand Icicle Spear (3 hits) vs. 0 HP / 0 Def Hippowdon: 258-312 (72.2 - 87.3%) -- approx. 2HKO

New with HH (only the first hit is boosted):
0 Atk Mamoswine Helping Hand Icicle Spear (3 hits) vs. 0 HP / 0 Def Hippowdon: 206-248 (57.7 - 69.4%) -- approx. 2HKO
