### PR TITLE
Remove Knock Off BP boost for raid bosses

### DIFF
--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -940,6 +940,7 @@ export function calculateBPModsSMSSSV(
   // Move effects
 
   let resistedKnockOffDamage =
+    (attacker.bossMultiplier > 100) ||
     (!defender.item || isQPActive(defender, field)) ||
     (defender.named('Dialga-Origin') && defender.hasItem('Adamant Crystal')) ||
     (defender.named('Palkia-Origin') && defender.hasItem('Lustrous Globe')) ||


### PR DESCRIPTION
In Tera Raids, bosses don't get the BP boost to Knock Off when their target is holding an item. 

Here, the `bossMultiplier` is used to determine when an attacker should be considered a raid boss.

Old (and when `bossMultiplier <= 100`):
+1 0+ Atk Tera Poison Swampert Knock Off (97.5 BP) vs. 252 HP / 0 Def Farigiraf through Def Cheer with 2 allies' Friend Guards on a critical hit: 187-220 (42.1 - 49.5%) -- guaranteed 3HKO

New (when `bossMultiplier > 100`):
+1 0+ Atk Tera Poison Swampert Knock Off vs. 252 HP / 0 Def Farigiraf through Def Cheer with 2 allies' Friend Guards on a critical hit: 127-150 (28.6 - 33.7%) -- 0.3% chance to 3HKO